### PR TITLE
fixed bug Unrecognized option "0" under "artgris_maintenance.ips"

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,8 +22,10 @@ class Configuration implements ConfigurationInterface
 
 	    $rootNode
 		    ->children()
-		    ->scalarNode("enable")->defaultValue(false)->end()
-		    ->arrayNode("ips")->end()
+                ->scalarNode("enable")->defaultValue(false)->end()
+                ->arrayNode("ips")
+                    ->prototype('scalar')->end()
+                ->end()
 		    ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
fixed `PHP Fatal error:  Uncaught Symfony\Component\Config\Definition\Exception\InvalidConfigurationException: Unrecognized option "0" under "artgris_maintenance.ips"`.

PS: symfony 3.2.x