### PR TITLE
changed isMasterRequest to isMainRequest in event listener

### DIFF
--- a/EventListener/MaintenanceListener.php
+++ b/EventListener/MaintenanceListener.php
@@ -57,7 +57,7 @@ class MaintenanceListener
     public function onKernelRequest(RequestEvent $event)
     {
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 


### PR DESCRIPTION
isMasterRequest is deprecated in Symfony 5.3