### PR TITLE
Add symfony v6.0 support, fix a deprecation in EventListener

### DIFF
--- a/EventListener/MaintenanceListener.php
+++ b/EventListener/MaintenanceListener.php
@@ -57,7 +57,7 @@ class MaintenanceListener
     public function onKernelRequest(RequestEvent $event)
     {
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     }
   ],
   "require": {
-    "php": ">=7.1.3",
+    "php": ">=8.0.2",
     "twig/twig": "^2.12|^3.0",
-    "symfony/config": "^4.4|^5.0"
+    "symfony/config": "^4.4|^5.0|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
As in subject. Bump Symfony version to 6.0, and fix a simple deprecation.